### PR TITLE
Neue Frontend-Ansicht: "Jetzt erreichbar" & nächste Telefonsprechzeiten (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# --- Python ---
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+
+# --- Virtual Environments ---
+.venv/
+venv/
+env/
+ENV/
+
+# --- Distribution / Packaging ---
+*.egg-info/
+*.egg
+build/
+dist/
+
+# --- Jupyter Notebook ---
+.ipynb_checkpoints
+
+# --- Logs / Temp ---
+*.log
+*.tmp
+*.DS_Store
+
+# --- IDE / Editor ---
+.vscode/
+.idea/
+*.swp
+
+# --- Data / Output ---
+*.xlsx
+*.xls
+*.csv
+*.json
+!images/Beispiel Template.xlsx
+
+# --- Streamlit Cache ---
+.streamlit/


### PR DESCRIPTION
Dieses PR implementiert eine neue Nutzeransicht im Frontend (Issue #6):

- Anzeige der aktuell telefonisch erreichbaren Praxen direkt auf der Seite
- Zusätzlich (auch falls niemand erreichbar ist): Anzeige der nächsten 5 verfügbaren Telefonsprechzeiten
- Suchergebnisse (Tabellen) bleiben auch nach Download sichtbar
- Download-Button ändert sich nach Klick zu "Erfolgreich heruntergeladen!" und wird deaktiviert

Fixes #6
